### PR TITLE
Add current state of 3dtrees_tile_merge

### DIFF
--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -56,7 +56,7 @@
         <data name="output_tile" format="zip" label="Prepared Files" from_work_dir="prepared_files.zip">
             <filter>operation['task'] == "tile"</filter>
         </data>
-        <data name="output_merge" format="laz" label="Merged Point Cloud" from_work_dir="final_pc.laz">
+        <data name="output_merge" format="laz" label="segmented" from_work_dir="segmented.laz">
             <filter>operation['task'] == "merge"</filter>
         </data>
     </outputs>
@@ -80,7 +80,7 @@
             </output>
         </test>
         <test expect_num_outputs="1">
-            <param name="input" value="processed_files_mikro.zip/>
+            <param name="input" value="processed_files_mikro.zip"/>
             <conditional name="operation">
                 <param name="task" value="merge"/>
             </conditional>

--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -2,7 +2,7 @@
     <description>Subsampling, tiling, merging and matching of point clouds</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.1</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <requirements>
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees_tile_merge:@TOOL_VERSION@</container>
@@ -18,6 +18,7 @@
             --tiling-threshold '$operation.tiling_threshold'
             --points-threshold '$operation.points_threshold'
             --subsampling-resolution '$operation.subsampling_resolution'
+            --number-of-threads \${GALAXY_SLOTS:-4}
         #end if
         #if $operation.task == 'merge':
             --buffer '$operation.buffer'
@@ -25,9 +26,10 @@
             --initial-radius '$operation.initial_radius'
             --max-radius '$operation.max_radius'
             --radius-step '$operation.radius_step'
+            --number-of-threads \${GALAXY_SLOTS:-4}
+            && mv final_pc.laz segmented.laz
         #end if
-        --number-of-threads \${GALAXY_SLOTS:-4}
-    ]]>
+            ]]>
     </command>
     <inputs>
         <param name="input" type="data" format="zip,laz" label="Input Point Cloud or ZIP file" help="Input LAS/LAZ point cloud file or ZIP file containing prepared files"/>


### PR DESCRIPTION
Solve the naming issue with the tool specification file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds per-task thread flags, renames merge output to segmented.laz, bumps version suffix, and fixes a test input quote.
> 
> - **Tool configuration (`tools/tile_merge.xml`)**:
>   - Add `--number-of-threads` within both `tile` and `merge` command branches.
>   - In `merge`, rename output by moving `final_pc.laz` to `segmented.laz`; update output to `from_work_dir="segmented.laz"` with label `segmented`.
>   - Bump `@VERSION_SUFFIX@` token from `0` to `1`.
> - **Tests**:
>   - Fix missing quote in `processed_files_mikro.zip` input parameter for the merge test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45db11e33a538292046b1fec942021fda348382d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->