### PR TITLE
Update standardization & tile_merge

### DIFF
--- a/tools/standard.xml
+++ b/tools/standard.xml
@@ -1,5 +1,5 @@
 <tool id="3dtrees_standardization" name="3DTrees LAS/LAZ Standardization" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
-    <description>Standardize individual LAS/LAZ point cloud files</description>
+    <description>Standardize LAS/LAZ files or validate collections for consistency</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.0</token>
         <token name="@VERSION_SUFFIX@">0</token>
@@ -7,57 +7,73 @@
     <requirements>
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees-pc-standard:@TOOL_VERSION@</container>
     </requirements>
-
-    <stdio>
-        <!-- Treat Docker platform warnings as non-fatal warnings -->
-        <regex match="WARNING: The requested image's platform.*does not match.*" 
-               source="stderr" 
-               level="warning" 
-               description="Docker platform mismatch warning" />
-        <!-- Treat any other warnings as non-fatal -->
-        <regex match="WARNING:.*" 
-               source="stderr" 
-               level="warning" 
-               description="Non-critical warning" />
-        <!-- Treat actual errors as fatal -->
-        <regex match="ERROR:.*" 
-               source="stderr" 
-               level="fatal" 
-               description="Critical error" />
-    </stdio>
-
     <command detect_errors="exit_code"><![CDATA[
         WORK_DIR=\$(pwd) &&
-        cp '$input' input.laz &&
-        /usr/local/bin/Rscript /src/run.R
-        --dataset-path "\$WORK_DIR/input.laz"
-        --output-dir "\$WORK_DIR"
-        --method single_file
-        --min-density '$min_density'
-        #if $removeable_attributes:
-            --removeable_attributes $removeable_attributes
+        #if $mode.task == 'single_file':
+            cp '$mode.input' input.laz &&
+            /usr/local/bin/Rscript /src/run.R
+            --dataset-path "\$WORK_DIR/input.laz"
+            --output-dir "\$WORK_DIR"
+            --method single_file
+            --min-density '$mode.min_density'
+            #if $mode.removeable_attributes:
+                --removeable_attributes $mode.removeable_attributes
+            #end if
+        #else:
+            mkdir -p input_files &&
+            #for $f in $mode.input_collection
+                cp '$f' input_files/'${f.element_identifier}.laz' &&
+            #end for
+            /usr/local/bin/Rscript /src/run.R
+            --dataset-path "\$WORK_DIR/input_files"
+            --output-dir "\$WORK_DIR"
+            --method collection
         #end if
     ]]></command>
 
     <inputs>
-        <param name="input" type="data" format="laz" label="Point Cloud File" 
-               help="LAS/LAZ point cloud file to standardize. Connect a collection and Galaxy will map over each file."/>
-        <param argument="--min-density" name="min_density" type="integer" min="1" max="10000" value="10" 
-               label="Minimum Point Density" 
-               help="Minimum acceptable point density in points per square meter. Default: 10 pts/m²"/>
-        <param name="removeable_attributes" type="text" value="" optional="true"
-               label="Attributes to Remove" 
-               help="Space-separated list of attribute names to remove (e.g., 'Intensity UserData'). Leave empty for auto-detection."/>
+        <conditional name="mode">
+            <param name="task" type="select" label="Mode">
+                <option value="single_file">Single File Standardization</option>
+                <option value="collection">Collection Validation</option>
+            </param>
+            <when value="single_file">
+                <param name="input" type="data" format="laz" label="Point Cloud File" 
+                       help="LAS/LAZ point cloud file to standardize (CRS validation, density check, format normalization)"/>
+                <param argument="--min-density" type="integer" min="1" max="10000" value="10" 
+                       label="Minimum Point Density" 
+                       help="Minimum acceptable point density in points per square meter. Default: 10 pts/m²"/>
+                <param name="removeable_attributes" type="text" value="" optional="true"
+                       label="Attributes to Remove" 
+                       help="Space-separated list of attribute names to remove (e.g., 'Intensity UserData'). Leave empty for auto-detection."/>
+            </when>
+            <when value="collection">
+                <param name="input_collection" type="data_collection" collection_type="list" format="laz" label="Point Cloud Collection" 
+                       help="Collection of LAZ/LAS files to validate for consistency (CRS homogeneity, attribute consistency, overlaps)"/>
+            </when>
+        </conditional>
     </inputs>
     <outputs>
-        <data name="pc_standardized" format="laz" label="standardized" from_work_dir="input.laz"/>
-        <data name="metadata_json" format="json" label="metadata" from_work_dir="input.json"/>
-        <data name="convex_hull" format="geojson" label="convex_hull" from_work_dir="input_convex_hull_wgs84.GeoJSON"/>
+        <data name="pc_standardized" format="laz" label="standardized" from_work_dir="input.laz">
+            <filter>mode['task'] == "single_file"</filter>
+        </data>
+        <data name="metadata_json" format="json" label="metadata" from_work_dir="input.json">
+            <filter>mode['task'] == "single_file"</filter>
+        </data>
+        <data name="convex_hull" format="geojson" label="convex_hull" from_work_dir="input_convex_hull_wgs84.GeoJSON">
+            <filter>mode['task'] == "single_file"</filter>
+        </data>
+        <data name="collection_summary" format="json" label="collection_summary" from_work_dir="collection_summary.json">
+            <filter>mode['task'] == "collection"</filter>
+        </data>
     </outputs>
     <tests>
         <test expect_num_outputs="3">
-            <param name="input" value="mikro.laz" ftype="laz"/>
-            <param name="min_density" value="10"/>
+            <conditional name="mode">
+                <param name="task" value="single_file"/>
+                <param name="input" value="mikro.laz" ftype="laz"/>
+                <param name="min_density" value="10"/>
+            </conditional>
             <output name="pc_standardized" ftype="laz">
                 <assert_contents>
                     <has_size min="1000"/>
@@ -69,7 +85,10 @@
     <help><![CDATA[
 **What it does**
 
-Standardizes individual LAS/LAZ point cloud files:
+This tool supports two modes:
+
+**Single File Mode** (standardization):
+Standardizes a single LAS/LAZ file:
 
 1. **LAS Validation**: Runs ``las_check()`` and fixes header issues
 2. **Bounding Box**: Validates and corrects header bounding box
@@ -79,17 +98,29 @@ Standardizes individual LAS/LAZ point cloud files:
 6. **Format Normalization**: Downgrades Point Data Format to ≤7 for compatibility
 7. **Attribute Cleanup**: Optionally removes specified attributes
 
-**Outputs:**
+**Outputs (single file mode):**
 - Standardized ``.laz`` file
 - Metadata JSON with pre/post standardization info
 - Convex hull GeoJSON in WGS84
 
+**Collection Mode** (validation):
+Validates collection consistency:
+
+- **CRS Homogeneity**: Checks if all files share the same coordinate reference system
+- **Attribute Consistency**: Verifies attribute names and types across files
+- **Tile Geometry**: Detects overlaps and gaps between tiles
+- **Global Statistics**: Computes aggregated statistics across all files
+- **Removeable Attributes**: Identifies attributes that are all-NA or constant-zero
+
+**Outputs (collection mode):**
+- ``collection_summary.json`` containing collection-level checks and flags, per-file metadata (CRS, attributes, point counts, convex hulls), and suggested removeable attributes for standardization
+
 **Workflow Usage**
 
-In collection-based workflows:
-1. Run **3DTrees Collection Check** first to validate the collection
-2. Connect collection to this tool - Galaxy maps over each file automatically
-3. Use ``removeable_attributes`` from collection check for cleaner output
+For collection-based workflows:
+1. Run this tool with **Collection Validation** first to check consistency
+2. Use the suggested ``removeable_attributes`` from the collection summary
+3. Then run this tool with **Single File Standardization** (Galaxy maps over collection automatically) for standardization
 
     ]]></help>
 

--- a/tools/standard.xml
+++ b/tools/standard.xml
@@ -11,7 +11,7 @@
         WORK_DIR=\$(pwd) &&
         #if $mode.task == 'single_file':
             cp '$mode.input' input.laz &&
-            /usr/local/bin/Rscript /src/run.R
+            Rscript /src/run.R
             --dataset-path "\$WORK_DIR/input.laz"
             --output-dir "\$WORK_DIR"
             --method single_file
@@ -24,7 +24,7 @@
             #for $f in $mode.input_collection
                 cp '$f' input_files/'${f.element_identifier}.laz' &&
             #end for
-            /usr/local/bin/Rscript /src/run.R
+            Rscript /src/run.R
             --dataset-path "\$WORK_DIR/input_files"
             --output-dir "\$WORK_DIR"
             --method collection

--- a/tools/standard.xml
+++ b/tools/standard.xml
@@ -1,4 +1,4 @@
-<tool id="3dtrees_standardization" name="3DTrees LAS/LAZ Standardization" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
+<tool id="3dtrees_standardization" name="3DTrees: LAS/LAZ Standardization" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
     <description>Standardize LAS/LAZ files or validate collections for consistency</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.0</token>
@@ -8,12 +8,11 @@
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees-pc-standard:@TOOL_VERSION@</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-        WORK_DIR=\$(pwd) &&
         #if $mode.task == 'single_file':
             cp '$mode.input' input.laz &&
             Rscript /src/run.R
-            --dataset-path "\$WORK_DIR/input.laz"
-            --output-dir "\$WORK_DIR"
+            --dataset-path "./input.laz"
+            --output-dir "."
             --method single_file
             --min-density '$mode.min_density'
             #if $mode.removeable_attributes:
@@ -25,8 +24,8 @@
                 cp '$f' input_files/'${f.element_identifier}.laz' &&
             #end for
             Rscript /src/run.R
-            --dataset-path "\$WORK_DIR/input_files"
-            --output-dir "\$WORK_DIR"
+            --dataset-path "./input_files"
+            --output-dir "."
             --method collection
         #end if
     ]]></command>
@@ -48,8 +47,8 @@
                        help="Space-separated list of attribute names to remove (e.g., 'Intensity UserData'). Leave empty for auto-detection."/>
             </when>
             <when value="collection">
-                <param name="input_collection" type="data_collection" collection_type="list" format="laz" label="Point Cloud Collection" 
-                       help="Collection of LAZ/LAS files to validate for consistency (CRS homogeneity, attribute consistency, overlaps)"/>
+                <param name="input_collection" type="data" format="laz" multiple="true" label="Point Cloud Collection" 
+                       help="Multiple LAZ/LAS files to validate for consistency (CRS homogeneity, attribute consistency, overlaps)"/>
             </when>
         </conditional>
     </inputs>
@@ -80,6 +79,17 @@
                 </assert_contents>
             </output>
         </test>
+        <test expect_num_outputs="1">
+            <conditional name="mode">
+                <param name="task" value="collection"/>
+                <param name="input_collection" value="mikro.laz,mikro2.laz" ftype="laz"/>
+            </conditional>
+            <output name="collection_summary" ftype="json">
+                <assert_contents>
+                    <has_text text="&quot;n_tiles&quot;: 2"/>
+                </assert_contents>
+            </output>
+        </test>
     </tests>
 
     <help><![CDATA[
@@ -104,7 +114,7 @@ Standardizes a single LAS/LAZ file:
 - Convex hull GeoJSON in WGS84
 
 **Collection Mode** (validation):
-Validates collection consistency:
+Validates consistency of multiple LAS/LAZ files:
 
 - **CRS Homogeneity**: Checks if all files share the same coordinate reference system
 - **Attribute Consistency**: Verifies attribute names and types across files

--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -2,7 +2,7 @@
     <description>Subsampling, tiling, merging and matching of point clouds</description>
     <macros>
         <token name="@TOOL_VERSION@">1.0.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees_tile_merge:@TOOL_VERSION@</container>

--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -12,13 +12,13 @@
         --dataset-path '$input' 
         --output-dir .
         --task '$operation.task'
+        --number-of-threads \${GALAXY_SLOTS:-4}
         #if $operation.task == 'tile':
             --tile-size '$operation.tile_size'
             --overlap '$operation.overlap'
             --tiling-threshold '$operation.tiling_threshold'
             --points-threshold '$operation.points_threshold'
             --subsampling-resolution '$operation.subsampling_resolution'
-            --number-of-threads \${GALAXY_SLOTS:-4}
         #end if
         #if $operation.task == 'merge':
             --buffer '$operation.buffer'
@@ -26,7 +26,6 @@
             --initial-radius '$operation.initial_radius'
             --max-radius '$operation.max_radius'
             --radius-step '$operation.radius_step'
-            --number-of-threads \${GALAXY_SLOTS:-4}
         #end if
             ]]>
     </command>
@@ -85,7 +84,11 @@
             <conditional name="operation">
                 <param name="task" value="merge"/>
             </conditional>
-            <output name="output_merge" file="segmented.laz" ftype="laz" compare="sim_size" delta="100000"/>
+            <output name="output_merge">
+                <assert_contents>
+                    <has_size value="200000" delta="100000"/>
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help format="markdown">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Standardization (`tools/standard.xml`)**
> 
> - Renames tool to `3DTrees: LAS/LAZ Standardization` and expands description.
> - Introduces a `mode` conditional with two paths: `single_file` (standardization) and `collection` (multi-file validation).
> - Refactors command: copies inputs per mode, switches to `Rscript`, sets `--method` (`single_file`/`collection`), threads work in current dir; removes previous `stdio` regex block.
> - Adds `collection_summary.json` output for collection mode; gates existing `pc_standardized`, `metadata_json`, and `convex_hull` outputs to single-file mode.
> - Updates tests: one for single-file (3 outputs, size check) and new collection-mode test asserting `"n_tiles": 2` in `collection_summary.json`.
> - Help rewritten to document both modes and workflow guidance.
> 
> **Tile/Merge (`tools/tile_merge.xml`)**
> 
> - Bumps `@VERSION_SUFFIX@` to `2`.
> - Moves `--number-of-threads` to top-level so it applies to both `tile` and `merge`; removes duplicates in conditionals.
> - Updates merge test to use `<assert_contents><has_size .../></assert_contents>` instead of `compare="sim_size"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a18b934eb911748931970a58de3bfb65e41f77f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->