### PR TITLE
Change spelling

### DIFF
--- a/tools/segmentanytree.xml
+++ b/tools/segmentanytree.xml
@@ -4,7 +4,7 @@
     </description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <container type="docker">
@@ -41,12 +41,12 @@
         <param argument="--log_file" type="boolean" label="Resource log" help="If set to true, it returns a log file containing the CPU, RAM and GPU usage statistics"/>
     </inputs>
     <outputs>
-        <data name="output" format="zip" label="processed_files">
+        <data name="output" format="zip" label="Processed Files">
             <change_format>
                 <when input="input.ext" value="laz" format="laz"/>
             </change_format>
         </data>
-        <data name="resource_usage" format="txt" label="resource_usage">
+        <data name="resource_usage" format="txt" label="Resource Usage">
             <filter>log_file</filter>
         </data>
     </outputs>

--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -1,8 +1,8 @@
 <tool id="3dtrees_tile_merge" name="3Dtrees: Tile and Merge" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="24.2">
     <description>Subsampling, tiling, merging and matching of point clouds</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.0.1</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@TOOL_VERSION@">1.0.2</token>
+        <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
         <container type="docker">ghcr.io/3dtrees-earth/3dtrees_tile_merge:@TOOL_VERSION@</container>

--- a/tools/tile_merge.xml
+++ b/tools/tile_merge.xml
@@ -53,10 +53,10 @@
         </conditional>
     </inputs>
     <outputs>
-        <data name="output_tile" format="zip" label="prepared_files" from_work_dir="prepared_files.zip">
+        <data name="output_tile" format="zip" label="Prepared Files" from_work_dir="prepared_files.zip">
             <filter>operation['task'] == "tile"</filter>
         </data>
-        <data name="output_merge" format="laz" label="segmented" from_work_dir="segmented.laz">
+        <data name="output_merge" format="laz" label="Segmented Point Cloud" from_work_dir="segmented.laz">
             <filter>operation['task'] == "merge"</filter>
         </data>
     </outputs>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns Galaxy tool wrappers and labels.
> 
> - Bumps `3dtrees_tile_merge` to `@TOOL_VERSION@` 1.0.2 (container tag updated) and resets `@VERSION_SUFFIX@` to `0`; resets `segmentanytree` `@VERSION_SUFFIX@` to `0`
> - Standardizes output labels to `Prepared Files`, `Segmented Point Cloud`, `Processed Files`, and `Resource Usage`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa5d54ff84ae7c244a1d4629320272ca2fefdc55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->